### PR TITLE
리다이렉트 페이지에서만 js 불러오도록 수정

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,9 +1,6 @@
 var link = window.location.href;
-if (link.includes("playentry.org/redirect?external=")) {
-    var targetUrl = link.split("external=")[1];
-    console.log("이동중")
-    if (targetUrl) {
-        var decodedUrl = decodeURIComponent(targetUrl);
-        window.location.href = decodedUrl;
-    }
+var targetUrl = link.split("external=")[1];
+if (targetUrl) {
+    var decodedUrl = decodeURIComponent(targetUrl);
+    window.location.href = decodedUrl;
 }

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,7 @@
   "permissions": [],
   "content_scripts": [
     {
-      "matches": ["<all_urls>"],
+      "matches": ["https://playentry.org/redirect?external=*"],
       "js": ["background.js"]
     }
   ]


### PR DESCRIPTION
최적화 및 해킹 방지를 위해 `manifest.json`피일의 `matches` 기능을 사용하여 리다이렉트 페이지인지 판별하게 수정하였습니다.